### PR TITLE
Remove -installsuffix, it's not needed anymore since 1.10

### DIFF
--- a/loader
+++ b/loader
@@ -17,7 +17,7 @@ if [ -n "$TAR" ]; then
 	)
 fi
 
-/usr/local/go/bin/go build -a -installsuffix cgo -ldflags "-linkmode external -extldflags \"-static\" -s -w $LDFLAGS" "$@" >&2
+/usr/local/go/bin/go build -a -ldflags "-linkmode external -extldflags \"-static\" -s -w $LDFLAGS" "$@" >&2
 
 if [ -n "$TAR" ]; then
 	tar -c .


### PR DESCRIPTION
See https://plus.google.com/117192131596509381660/posts/eNnNePihYnK and https://github.com/golang/go/issues/9344#issuecomment-69944514